### PR TITLE
Basic indentation

### DIFF
--- a/smali2java/Program.cs
+++ b/smali2java/Program.cs
@@ -15,10 +15,14 @@ namespace Smali2Java
 
             String sFile = args.Length > 0 ? args[0] : "Samples\\AndroidHandler.smali";
 
+            Console.BufferHeight = 10000;
+            Console.WindowWidth = Console.LargestWindowWidth;
+            Console.BufferWidth = Console.LargestWindowWidth;
+
             Console.WriteLine("Decompiling file: " + sFile);
             Console.WriteLine("[");
             SmaliEngine e = new SmaliEngine();
-            Console.Write(e.Decompile(sFile));
+            Console.Write(e.Indent(e.Decompile(sFile)));
             Console.WriteLine("]");
             Console.ReadKey();
         }

--- a/smali2java/Smali/SmaliEngine.cs
+++ b/smali2java/Smali/SmaliEngine.cs
@@ -21,7 +21,7 @@ namespace Smali2Java
                 if (l != null)
                     Lines.Add(l);
             }
-            
+
             SmaliClass c = new SmaliClass();
             c.Lines = Lines;
             c.LoadAttributes();
@@ -29,12 +29,40 @@ namespace Smali2Java
             c.LoadMethods();
 
             StringBuilder sb = new StringBuilder();
-            
+
             sb.Append(c.ToJava());
-            
-            rv = sb.ToString();            
+
+            rv = sb.ToString();
             return rv;
         }
 
+        public String Indent(String java)
+        {
+            int indentation = 0;
+            String indenter = "    ";
+            StringBuilder sb = new StringBuilder();
+
+            string[] lines = java.Split('\n');
+            for (int i = 0; i < lines.Length; i++)
+            {
+                if (lines[i].TrimStart().Contains("}"))
+                {
+                    indentation--;
+                }
+
+                for (int n = 0; n < indentation; n++)
+                {
+                    sb.Append(indenter);
+                }
+                sb.AppendFormat("{0}\n", lines[i]);
+
+                if (lines[i].TrimStart().Contains("{"))
+                {
+                    indentation++;
+                }
+            }
+
+            return sb.ToString();
+        }
     }
 }


### PR DESCRIPTION
A quick indentation method to make for easier reading. It will probably fail on any strings containing '{' or '}'.
